### PR TITLE
Removes MinGW from build list

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -27,17 +27,6 @@ jobs:
             install_script: "install-windows-deps.ps1"
           }
           - {
-            name: "Windows Latest MinGW",
-            os: windows-latest,
-            artifact: "windows_mingw.7z",
-            build_type: "Release",
-            cc: "gcc",
-            cxx: "g++",
-            archiver: "7z a",
-            generators: "Ninja",
-            install_script: "install-windows-deps.ps1"
-          }
-          - {
             name: "Ubuntu_Latest_GCC",
             os: ubuntu-latest,
             artifact: "ubuntu_gcc.7z",


### PR DESCRIPTION
There's an issue with the github action setup of MinGW and gtest. Since I use MinGW locally it should be safe to remove this for now 